### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/tools/buildbot/generate_headers.py
+++ b/tools/buildbot/generate_headers.py
@@ -52,7 +52,7 @@ def output_version_headers():
   with open(os.path.join(SourceFolder, 'product.version')) as fp:
     contents = fp.read()
   m = re.match('(\d+)\.(\d+)\.(\d+)-?(.*)', contents)
-  if m == None:
+  if m is None:
     raise Exception('Could not detremine product version')
   major, minor, release, tag = m.groups()
   product = "{0}.{1}.{2}.{3}".format(major, minor, release, count)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:sourcemod?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:sourcemod?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
