### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tools/ida_scripts/vtable_dump.py
+++ b/tools/ida_scripts/vtable_dump.py
@@ -216,18 +216,18 @@ def Analyze():
 	while len(overload_stack) > 0:
 		windows_vtable.append(overload_stack.pop())
 	
-	print "\nVTable for %s: (0, 0)" % (classname)
+	print "\nVTable for {0!s}: (0, 0)".format((classname))
 	print " Lin  Win Function"
 	for i, v in enumerate(linux_vtable):
 		if "__cxa_pure_virtual" in v:
-			print "P%3d" % (i)
+			print "P{0:3d}".format((i))
 			continue
 		
 		winindex = windows_vtable.index(v) if v in windows_vtable else None
 		if winindex is not None:
-			print "%4d %4d %s" % (i, winindex, v)
+			print "{0:4d} {1:4d} {2!s}".format(i, winindex, v)
 		else:
-			print "%4d      %s" % (i, v)
+			print "{0:4d}      {1!s}".format(i, v)
 	
 	for k in temp_other_windows_vtables:
 		for i, v in enumerate(temp_other_windows_vtables[k]):
@@ -260,18 +260,18 @@ def Analyze():
 			prev_symbol = v
 	
 	for k in other_linux_vtables:
-		print "\nVTable for %s: (%d, %d)" % (offsetdata[k], offsetdata.keys().index(k) + 1, k)
+		print "\nVTable for {0!s}: ({1:d}, {2:d})".format(offsetdata[k], offsetdata.keys().index(k) + 1, k)
 		print " Lin  Win Function"
 		for i, v in enumerate(other_linux_vtables[k]):
 			if "__cxa_pure_virtual" in v:
-				print "P%3d" % (i)
+				print "P{0:3d}".format((i))
 				continue
 			
 			winindex = other_windows_vtables[k].index(v)
 			if v not in other_thunk_linux_vtables[k]:
-				print "%4d %4d %s" % (i, winindex, v)
+				print "{0:4d} {1:4d} {2!s}".format(i, winindex, v)
 			else:
-				print "T%3d %4d %s" % (i, winindex, v)
+				print "T{0:3d} {1:4d} {2!s}".format(i, winindex, v)
 	
 	SetStatus(IDA_STATUS_READY)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:sourcemod?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:sourcemod?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
